### PR TITLE
[Draft] Remote storage reads based on oldest timestamp in local storage

### DIFF
--- a/storage/local/interface.go
+++ b/storage/local/interface.go
@@ -101,6 +101,8 @@ type SeriesIterator interface {
 	RangeValues(metric.Interval) []model.SamplePair
 	// Returns the metric of the series that the iterator corresponds to.
 	Metric() metric.Metric
+	// Returns the timestamp of the first sample in the series.
+	FirstTime() model.Time
 	// Closes the iterator and releases the underlying data.
 	Close()
 }

--- a/storage/local/storage.go
+++ b/storage/local/storage.go
@@ -568,6 +568,11 @@ func (bit *boundedIterator) Metric() metric.Metric {
 	return bit.it.Metric()
 }
 
+// FirstTime implements SeriesIterator.
+func (bit *boundedIterator) FirstTime() model.Time {
+	return bit.it.FirstTime()
+}
+
 // Close implements SeriesIterator.
 func (bit *boundedIterator) Close() {
 	bit.it.Close()

--- a/storage/remote/iterator.go
+++ b/storage/remote/iterator.go
@@ -30,6 +30,13 @@ func (it sampleStreamIterator) Metric() metric.Metric {
 	return metric.Metric{Metric: it.ss.Metric}
 }
 
+func (it sampleStreamIterator) FirstTime() model.Time {
+	if len(it.ss.Values) == 0 {
+		return model.Latest
+	}
+	return it.ss.Values[0].Timestamp
+}
+
 func (it sampleStreamIterator) ValueAtOrBeforeTime(ts model.Time) model.SamplePair {
 	// TODO: This is a naive inefficient approach - in reality, queries go mostly
 	// linearly through iterators, and we will want to make successive calls to


### PR DESCRIPTION
Currently all read queries are simply pushed to remote storage.
We need instead to compare the oldest timestamp in local storage
with the query range lower boundary. If the oldest timestamp is
older than the from parameter, then there is no need for remote
storage calls.
This commit add FirstTime() in SeriesIterator interface,
and logic to use it.

Fixes #3041.

Signed-off-by: Thibault Chataigner <t.chataigner@criteo.com>