### PR TITLE
Set the ValidUntil to be 5x instead of 3x

### DIFF
--- a/rules/alerting.go
+++ b/rules/alerting.go
@@ -475,7 +475,7 @@ func (r *AlertingRule) sendAlerts(ctx context.Context, ts time.Time, resendDelay
 			if interval > resendDelay {
 				delta = interval
 			}
-			alert.ValidUntil = ts.Add(3 * delta)
+			alert.ValidUntil = ts.Add(5 * delta)
 			anew := *alert
 			alerts = append(alerts, &anew)
 		}


### PR DESCRIPTION
As seen in practice 3x can be quite tight because of the delays in
sending the events from prometheus to alertmanager
This leads to flappy alerts (firing->resolved->firing....)
This is easily seen when there are lots of alerts that
remain in firing state for long